### PR TITLE
driver: allow setting network device prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ $ docker run --net=mynet -itd --name=web nginx
 2. mode - passthrough/sriov
 3. vlan - vlan offload to use for child netdevices
 4. privileged - indicating privileged network that can sniff packets, and modify L2 addresses
+5. prefix - prefix of the interface name within the container (default: "eth")
 
 ### Limitations
 


### PR DESCRIPTION
To be able to distinguish a passed-through interface (which might have
special characteristics) inside a container, it is useful to control the
naming of such an interface. Add an option to configure the prefix
Docker will assign to interfaces on a per-network basis.

Signed-off-by: Florian Larysch <fl@n621.de>